### PR TITLE
fix(app): the share extension's callback is a nudge, not a destination (OPH-298)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,18 @@ jobs:
       # Credentials match the docker-compose defaults the tests assume; the
       # test bootstrap creates the bucket itself (with retries), so no
       # healthcheck choreography is needed.
+      #
+      # Pulled from quay.io, which is MinIO's own registry: the Docker Hub
+      # mirror this used to name is GONE — `docker pull minio/minio:latest`
+      # answers "pull access denied … repository does not exist", and
+      # registry-1.docker.io returns 401 for its manifest while quay.io
+      # returns 200 (measured 2026-09-12, OPH-298's CI round). Both API jobs
+      # died here, before a single integration test ran.
       - name: Start MinIO (attachments storage)
         run: |
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=alliswell -e MINIO_ROOT_PASSWORD=alliswell_dev \
-            minio/minio:latest server /data
+            quay.io/minio/minio:latest server /data
 
       - name: Integration tests
         run: npm run test:integration
@@ -193,7 +200,7 @@ jobs:
         run: |
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=alliswell -e MINIO_ROOT_PASSWORD=alliswell_dev \
-            minio/minio:latest server /data
+            quay.io/minio/minio:latest server /data
 
       - name: Integration tests
         run: npm run test:integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) • Versioning:
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sharing a text into AllisWell on iOS ends in the app, not on an error
+  screen.** "Paylaş → AllisWell" saved the text and then showed *"Bir şeyler
+  ters gitti — bu bağlantı AllisWell'in bu sürümünde bir yere gitmiyor"* with
+  `sharemedia-com.alliswell.alliswell:/share` underneath, and no task was
+  created. The share extension announces itself by opening that URL after it
+  has written the payload to the App Group; iOS 26 delivers the open (iOS 18
+  did not, which is what ADR-0029 had measured), no plugin claims it under the
+  UIScene lifecycle, and Flutter therefore handed it to the router as a plain
+  location that matched no route. The app now treats it as what it is — a
+  nudge, not a destination: the scene delegate drops it, the router answers it
+  with Home, and the shell still drains the App Group, so the shared text
+  reaches the AI exactly as it does on Android. A payload that arrives while
+  the shell is off screen is no longer stranded either.
+
 ### Changed
 
 - **The iPhone app is on the App Store.** The homepage (both languages) and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) • Versioning:
 
 ### Fixed
 
+- **CI and `docker-compose` pull MinIO from quay.io.** Docker Hub's
+  `minio/minio` is gone — `docker pull` answers *"pull access denied …
+  repository does not exist"*, and its registry returns 401 for the manifest
+  quay.io serves with 200. Both API jobs died on the container start, before a
+  single integration test ran, and a fresh `docker compose up` hit the same
+  wall. quay.io is MinIO's own registry; nothing else about the service
+  changes.
 - **Sharing a text into AllisWell on iOS ends in the app, not on an error
   screen.** "Paylaş → AllisWell" saved the text and then showed *"Bir şeyler
   ters gitti — bu bağlantı AllisWell'in bu sürümünde bir yere gitmiyor"* with

--- a/apps/app/ios/Runner/SceneDelegate.swift
+++ b/apps/app/ios/Runner/SceneDelegate.swift
@@ -41,7 +41,7 @@ class SceneDelegate: FlutterSceneDelegate {
   /// options above, which are read-only — so Dart guards it as well
   /// (`awIsShareCallback`, `core/deep_link.dart`).
   override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    let forwarded = URLContexts.filter { !Self.isShareCallback($0.url) }
+    let forwarded = URLContexts.filter { !self.isShareCallback($0.url) }
     if !forwarded.isEmpty {
       super.scene(scene, openURLContexts: forwarded)
     }
@@ -52,7 +52,7 @@ class SceneDelegate: FlutterSceneDelegate {
   /// `\(kSchemePrefix)-\(hostAppBundleIdentifier):share`. Compared lowercased
   /// because iOS normalizes the scheme it hands over, and derived from the
   /// bundle id so a flavor with its own identifier needs no edit here.
-  private static func isShareCallback(_ url: URL) -> Bool {
+  private func isShareCallback(_ url: URL) -> Bool {
     guard let scheme = url.scheme?.lowercased(),
       let bundleId = Bundle.main.bundleIdentifier?.lowercased()
     else { return false }

--- a/apps/app/ios/Runner/SceneDelegate.swift
+++ b/apps/app/ios/Runner/SceneDelegate.swift
@@ -20,9 +20,43 @@ class SceneDelegate: FlutterSceneDelegate {
     remember(connectionOptions.urlContexts)
   }
 
+  /// The share extension's callback stops here (OPH-298, amends ADR-0029).
+  ///
+  /// ADR-0029 measured `ShareMedia-<bundle id>:share` as an open that can
+  /// never arrive — an appex could not foreground its host app on iOS 18. On
+  /// iOS 26 it DOES arrive, and nothing native claims it: the plugin only
+  /// registers the pre-UIScene `application:openURL:options:` callbacks. An
+  /// unclaimed URL is handed to the framework as a plain ROUTE, which is how a
+  /// share that had in fact been saved ended on "Bu bağlantı … bir yere
+  /// gitmiyor".
+  ///
+  /// Dropping it loses nothing. The payload is already in the App Group, the
+  /// app is already coming forward, and `shareBinderProvider` drains the
+  /// mailbox on that resume — this only stops a nudge from impersonating a
+  /// destination, and keeps the drain the single transport it was decided to
+  /// be (the plugin's own `handleUrl` does not clear the mailbox, so letting
+  /// it read too would turn one share into two tasks).
+  ///
+  /// The COLD path cannot be filtered here — it arrives in the connection
+  /// options above, which are read-only — so Dart guards it as well
+  /// (`awIsShareCallback`, `core/deep_link.dart`).
   override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    super.scene(scene, openURLContexts: URLContexts)
+    let forwarded = URLContexts.filter { !Self.isShareCallback($0.url) }
+    if !forwarded.isEmpty {
+      super.scene(scene, openURLContexts: forwarded)
+    }
     remember(URLContexts)
+  }
+
+  /// `RSIShareViewController` builds the URL as
+  /// `\(kSchemePrefix)-\(hostAppBundleIdentifier):share`. Compared lowercased
+  /// because iOS normalizes the scheme it hands over, and derived from the
+  /// bundle id so a flavor with its own identifier needs no edit here.
+  private static func isShareCallback(_ url: URL) -> Bool {
+    guard let scheme = url.scheme?.lowercased(),
+      let bundleId = Bundle.main.bundleIdentifier?.lowercased()
+    else { return false }
+    return scheme == "sharemedia-\(bundleId)"
   }
 
   private func remember(_ contexts: Set<UIOpenURLContext>) {

--- a/apps/app/lib/src/core/deep_link.dart
+++ b/apps/app/lib/src/core/deep_link.dart
@@ -65,3 +65,31 @@ String? awRouteForUri(Uri uri) {
 /// omission is a decision, not an oversight (ADR-0016).
 bool awIsBackgroundAction(Uri uri) =>
     uri.scheme == kAwScheme && (uri.host == 'complete' || uri.host == 'add');
+
+/// The iOS share extension's callback scheme: `ShareMedia-<host bundle id>`
+/// (OPH-298, amends ADR-0029).
+///
+/// `RSIShareViewController.redirectToHostApp()` opens
+/// `ShareMedia-<bundle id>:share` AFTER it has written the App Group.
+/// ADR-0029 measured that open as a no-op on iOS 18 and built the App Group
+/// drain because of it — but on iOS 26 it ARRIVES, and under the UIScene
+/// lifecycle no plugin claims it, so Flutter hands the URL to the router as a
+/// plain LOCATION. It matched no route, so the share ended on the error screen
+/// ("Bu bağlantı … bir yere gitmiyor") — worse than the silence it replaced,
+/// because that screen lives OUTSIDE the shell and the shell is what drains
+/// the payload.
+///
+/// So this is not a destination, it is a NUDGE: the shared text never travels
+/// in the URL (it is in the App Group), and the only thing the app owes this
+/// URL is to come forward without an error.
+///
+/// Matched on the prefix alone, deliberately. The suffix is the host bundle id,
+/// which differs per flavor, and the worst a forged `sharemedia-…:` link can
+/// achieve is Home — this table only ever navigates.
+const String kAwShareCallbackPrefix = 'sharemedia-';
+
+/// True for the share extension's callback URL. `Uri` lowercases the scheme
+/// and so does iOS on delivery; the extra `toLowerCase()` costs nothing and
+/// makes the match independent of both.
+bool awIsShareCallback(Uri uri) =>
+    uri.scheme.toLowerCase().startsWith(kAwShareCallbackPrefix);

--- a/apps/app/lib/src/router.dart
+++ b/apps/app/lib/src/router.dart
@@ -178,7 +178,13 @@ final routerProvider = Provider<GoRouter>((ref) {
         final pending = ref.read(pendingDeepLinkProvider.notifier).take();
         if (pending != null && pending != state.matchedLocation) return pending;
       }
-      if (auth.value == null && !auth.isLoading) {
+      // OPH-298: the share extension's callback is NOT a destination, so it is
+      // never remembered. Replaying it after sign-in would replay an
+      // unroutable location; the payload it announces waits in the App Group
+      // and the shell drains it the moment it mounts.
+      if (auth.value == null &&
+          !auth.isLoading &&
+          !awIsShareCallback(state.uri)) {
         final wanted = awRouteForUri(state.uri) ?? state.matchedLocation;
         if (!_authLocations.contains(wanted) && wanted != '/splash') {
           ref.read(pendingDeepLinkProvider.notifier).remember(wanted);
@@ -197,6 +203,16 @@ final routerProvider = Provider<GoRouter>((ref) {
     // the "error page" is a real route with a working way out.
     onException: (context, state, router) {
       final uri = state.uri;
+      // OPH-298: the iOS share extension's `ShareMedia-<bundle id>:share`
+      // callback. ADR-0029 expected it never to arrive; on iOS 26 it does, and
+      // it used to land on `/not-found` — an error screen for a share that had
+      // in fact been saved, and (because that screen lives outside the shell)
+      // the reason the App Group was never drained. Home is the answer to both
+      // halves: no error, and the surface that consumes the payload is mounted.
+      if (awIsShareCallback(uri)) {
+        router.go(AppSection.home.path);
+        return;
+      }
       final resolved = awRouteForUri(uri);
       if (resolved != null) {
         router.go(resolved);

--- a/apps/app/lib/src/screens/home_shell.dart
+++ b/apps/app/lib/src/screens/home_shell.dart
@@ -225,6 +225,18 @@ class HomeShell extends ConsumerWidget {
       final payload = ref.read(pendingSharePayloadProvider.notifier).take();
       if (payload != null) unawaited(_routeShare(context, ref, payload));
     });
+    // OPH-298: …and one that arrived while this shell was NOT on screen.
+    // `ref.listen` only ever fires on CHANGE, and the binder outlives the
+    // shell (it is not auto-disposed), so a payload remembered while the user
+    // sat on a pushed screen — or on the error screen the share callback used
+    // to produce — was held in memory and shown to nobody. Sweeping the holder
+    // after the frame closes that: `take()` is read-and-clear, so it can never
+    // double-deliver with the listener above.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!context.mounted) return;
+      final waiting = ref.read(pendingSharePayloadProvider.notifier).take();
+      if (waiting != null) unawaited(_routeShare(context, ref, waiting));
+    });
 
     // Round 16 follow-up: the OS opened a .md file with us. The viewer TAKES
     // the pending document itself, so this only has to get the user there —

--- a/apps/app/test/features/ai/share_routing_test.dart
+++ b/apps/app/test/features/ai/share_routing_test.dart
@@ -3,10 +3,13 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:alliswell/src/app.dart';
 import 'package:alliswell/src/core/retry.dart';
+import 'package:alliswell/src/i18n/i18n.dart';
+import 'package:alliswell/src/router.dart';
 import 'package:alliswell/src/features/ai/data/ai_context_builder.dart';
 import 'package:alliswell/src/features/ai/ui/ai_bubble.dart';
 import 'package:alliswell/src/features/ai/ui/ai_settings_screen.dart';
@@ -314,6 +317,152 @@ void main() {
       api.tasks.where((t) => t['status'] == 'inbox'),
       hasLength(1),
       reason: 'one-directional means cheap, not lossy',
+    );
+  });
+
+  // ── Round 21 (OPH-298): the callback ADR-0029 said could never arrive ─────
+  //
+  // `RSIShareViewController` opens `ShareMedia-<bundle id>:share` after it has
+  // written the App Group. ADR-0029 measured that open as impossible on iOS 18
+  // and built the drain because of it — but on iOS 26 it ARRIVES, no plugin
+  // claims it under the UIScene lifecycle, and go_router received it as a
+  // LOCATION. It matched no route, so a share that had in fact been saved
+  // ended on the error screen; worse, that screen lives OUTSIDE the shell, so
+  // the drain that would have read the payload never ran. The report was "I
+  // shared a text and got an error", and the text was sitting in the mailbox.
+  //
+  // The two payload tests run with AI configured: that is the reported setup
+  // (the expectation was a task, structured by the model) and it is the
+  // destination tests 5–6 above already pin as stable. The third asserts the
+  // location alone, which needs no payload at all.
+  String errorScreenMessage() => 'error.routeNotFound'.tr();
+
+  GoRouter routerOf() => GoRouter.of(awRootNavigatorKey.currentContext!);
+
+  /// Pumps until [finder] matches, then settles.
+  ///
+  /// `pumpAndSettle` stops as soon as no FRAME is scheduled, which is not the
+  /// same as "the chain finished": routing a share runs mailbox → workspace →
+  /// AI status (both budgeted) → the surface, and a Future waiting on the fake
+  /// transport schedules no frame at all. The callback URL puts a navigation in
+  /// front of that chain, which is why the plugin path settles in one pump and
+  /// this one does not.
+  Future<void> pumpUntilShown(WidgetTester tester, Finder finder) async {
+    for (var i = 0; i < 60 && finder.evaluate().isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a COLD start on the callback URL opens the share, not the '
+      'error screen', (tester) async {
+    wide(tester);
+    // The real cold-start shape: iOS hands the URL to the scene's connection
+    // options, and Flutter turns that into the initial route.
+    tester.binding.platformDispatcher.defaultRouteNameTestValue =
+        'ShareMedia-com.alliswell.alliswell:share';
+    addTearDown(
+      tester.binding.platformDispatcher.clearDefaultRouteNameTestValue,
+    );
+    final api = FakeApi()..aiEnabled = true;
+    api.seedAiConnection(provider: 'anthropic');
+    final share = FakeShareIntentSource();
+    addTearDown(share.dispose);
+    // What the extension left behind before it opened the URL.
+    final inbox = FakeShareInbox(
+      pending: const SharedPayload(text: 'Gmail’den paylaşıldı'),
+    );
+
+    await tester.pumpWidget(
+      await _app(
+        api,
+        share: share,
+        inbox: inbox,
+        prefs: _cachedAiStatus(configured: true),
+      ),
+    );
+    await pumpUntilShown(tester, find.byType(AiBubble));
+
+    expect(find.text(errorScreenMessage()), findsNothing);
+    expect(routerOf().state.uri.toString(), '/home');
+    expect(
+      find.byType(AiBubble),
+      findsOneWidget,
+      reason: 'the callback is a nudge; the payload still routes normally',
+    );
+    expect(inbox.takes, greaterThan(0));
+  });
+
+  testWidgets('a WARM callback is not an unroutable location', (tester) async {
+    // The narrow, deterministic half of the fix. The cold start above is
+    // rescued by the auth redirect as well (a restoring session parks every
+    // location on /splash), so it cannot see this on its own — and the report
+    // came from a warm app, where nothing else stands between the callback URL
+    // and `onException`.
+    wide(tester);
+    final api = FakeApi();
+    final share = FakeShareIntentSource();
+    addTearDown(share.dispose);
+
+    await tester.pumpWidget(await _app(api, share: share));
+    await tester.pumpAndSettle();
+
+    routerOf().go('ShareMedia-com.alliswell.alliswell:share');
+    await tester.pumpAndSettle();
+
+    expect(routerOf().state.uri.toString(), '/home');
+    expect(find.text(errorScreenMessage()), findsNothing);
+  });
+
+  testWidgets('a share that arrives while the shell is off screen is still '
+      'delivered', (tester) async {
+    wide(tester);
+    final api = FakeApi()..aiEnabled = true;
+    api.seedAiConnection(provider: 'anthropic');
+    final share = FakeShareIntentSource();
+    addTearDown(share.dispose);
+    final inbox = FakeShareInbox();
+
+    await tester.pumpWidget(
+      await _app(
+        api,
+        share: share,
+        inbox: inbox,
+        prefs: _cachedAiStatus(configured: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The user is on a pushed screen — outside the shell, which is also where
+    // the error screen lived. `ref.listen` fires on CHANGE only, so a payload
+    // remembered while this screen is up has no consumer at all.
+    routerOf().go('/settings/ai');
+    await tester.pumpAndSettle();
+    expect(find.byType(AiSettingsScreen), findsOneWidget);
+
+    // Share → Post: the extension fills the mailbox, the app comes forward, and
+    // iOS opens the callback URL.
+    inbox.deliver(const SharedPayload(text: 'uzantı yazdı, app önde değildi'));
+    for (final state in [
+      AppLifecycleState.inactive,
+      AppLifecycleState.hidden,
+      AppLifecycleState.paused,
+      AppLifecycleState.hidden,
+      AppLifecycleState.inactive,
+      AppLifecycleState.resumed,
+    ]) {
+      tester.binding.handleAppLifecycleStateChanged(state);
+    }
+    await tester.pumpAndSettle();
+    routerOf().go('ShareMedia-com.alliswell.alliswell:share');
+    await pumpUntilShown(tester, find.byType(AiBubble));
+
+    expect(find.text(errorScreenMessage()), findsNothing);
+    expect(inbox.takes, greaterThan(0));
+    expect(
+      find.byType(AiBubble),
+      findsOneWidget,
+      reason: 'a payload remembered with no listener must not be stranded',
     );
   });
 }

--- a/apps/app/test/features/widgets/deep_link_test.dart
+++ b/apps/app/test/features/widgets/deep_link_test.dart
@@ -75,6 +75,48 @@ void main() {
     });
   });
 
+  /// OPH-298 — the share extension's callback (amends ADR-0029).
+  ///
+  /// ADR-0029 decided the appex could never open the host app, so nothing knew
+  /// this URL. On iOS 26 it arrives, unclaimed by any plugin, and go_router
+  /// received it as a LOCATION: a share that had been saved ended on the error
+  /// screen instead of in the Inbox.
+  group('awIsShareCallback', () {
+    test('recognizes the URL the extension actually opens', () {
+      // `RSIShareViewController` builds `ShareMedia-<bundle id>:share`; the
+      // second form is what go_router's normalizer makes of it, and it is the
+      // string that was printed under the error screen's message.
+      for (final raw in [
+        'ShareMedia-com.alliswell.alliswell:share',
+        'sharemedia-com.alliswell.alliswell:/share',
+        // A flavor with its own bundle id must not need an edit here.
+        'sharemedia-space.alliswell.dev:share',
+      ]) {
+        expect(awIsShareCallback(Uri.parse(raw)), isTrue, reason: raw);
+      }
+    });
+
+    test('is not a destination — it announces, it does not carry', () {
+      // The payload travels in the App Group; the URL says only "come
+      // forward". Resolving it to a route would be inventing a meaning.
+      final callback = Uri.parse('sharemedia-com.alliswell.alliswell:share');
+      expect(awRouteForUri(callback), isNull);
+      expect(awIsBackgroundAction(callback), isFalse);
+    });
+
+    test('and nothing else is mistaken for it', () {
+      for (final other in [
+        'alliswell://open',
+        'https://alliswell.space/tasks',
+        'sharemedia:share',
+        'sharemedia.com.alliswell:share',
+        'file:///tmp/not.md',
+      ]) {
+        expect(awIsShareCallback(Uri.parse(other)), isFalse, reason: other);
+      }
+    });
+  });
+
   group('handleWidgetAction (OPH-188)', () {
     late AwDatabase db;
 

--- a/apps/app/test/native_config_test.dart
+++ b/apps/app/test/native_config_test.dart
@@ -115,6 +115,45 @@ void main() {
     });
   });
 
+  // OPH-298 (amends ADR-0029): the callback ADR-0029 was sure could not
+  // happen. On iOS 26 the appex's open ARRIVES, no plugin claims it under the
+  // UIScene lifecycle, and Flutter turns an unclaimed URL into a ROUTE — which
+  // put a share that had already been saved on the error screen. The scene
+  // delegate drops it; this is the line that keeps it dropped.
+  group('iOS scene delegate', () {
+    late final String scene = File(
+      'ios/Runner/SceneDelegate.swift',
+    ).readAsStringSync();
+
+    test('forwards the FILTERED contexts, never the raw set', () {
+      expect(
+        _code(scene),
+        contains('super.scene(scene, openURLContexts: forwarded)'),
+        reason:
+            'Handing the raw set to super forwards the share callback to '
+            'Flutter, which routes it, which is OPH-298 all over again.',
+      );
+      expect(
+        _code(scene),
+        isNot(contains('super.scene(scene, openURLContexts: URLContexts)')),
+      );
+    });
+
+    test('recognizes the callback by scheme, and only that', () {
+      // Derived from the bundle id so a flavor needs no edit, and lowercased
+      // because iOS normalizes the scheme it delivers.
+      expect(_code(scene), contains('sharemedia-'));
+      expect(_code(scene), contains('Bundle.main.bundleIdentifier'));
+      expect(
+        _code(scene),
+        contains('isFileURL'),
+        reason:
+            'the document handle still takes file URLs only (ADR-0030) — a '
+            'filter that swallowed those would break "Open in AllisWell".',
+      );
+    });
+  });
+
   group('iOS Info.plist', () {
     late final String plist = File('ios/Runner/Info.plist').readAsStringSync();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,9 @@ services:
   # automatically the first time the integration tests run (or make it yourself
   # in the console at http://localhost:9001).
   minio:
-    image: minio/minio:latest
+    # quay.io is MinIO's own registry; the Docker Hub mirror is gone (it now
+    # answers "repository does not exist" — 2026-09-12).
+    image: quay.io/minio/minio:latest
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -3,7 +3,31 @@
 > This file is the pointer for the "do the next task" (TR: _"sıradaki işi yap"_) workflow.
 > Always read it first; always update it before finishing a session. Backlog: [TASKS.md](TASKS.md).
 
-**Last updated:** 2026-09-04 (**Epic 27 — API'NİN BİR ÜRÜN YÜZEYİ OLMASI (istek turu 20).
+**Last updated:** 2026-09-12 (**Epic 28 — PAYLAŞILAN YAZI UYGULAMADA BİTSİN
+(istek turu 21). OPH-298.** Rapor + ekran görüntüsü: "Paylaş → AllisWell" dedi,
+uygulama açıldı ve *"Bir şeyler ters gitti — bu bağlantı AllisWell'in bu
+sürümünde bir yere gitmiyor"* dedi; altında `sharemedia-com.alliswell.alliswell:/share`.
+Beklenen: yapay zekânın yazıyı görev yapması. **Turun cümlesi: paylaşım
+BAŞARILIYDI — hata ekranı, başarılı paylaşımın "geldim" demek için açtığı URL'i
+bir ADRES sandığımız için çıktı.** Ekrandaki dizenin kendisi kanıt: `:/share`
+biçimi go_router `normalizeUri`'sinin `ShareMedia-<bundle id>:share` üzerindeki
+izi, yani URL `RSIShareViewController.redirectToHostApp()`'ten gelmiş ve
+ulaşmış. ADR-0029 bunun iOS 18'de imkânsız olduğunu ÖLÇMÜŞTÜ; iOS 26'da
+geliyor — ölçüm eskidi, karar değil (ADR yerinde tadil edildi). Üç katman:
+appex artık öne getirebiliyor · plugin yalnızca UIScene öncesi kancaları kuruyor
+(bizde `FlutterSceneDelegate`) · sahipsiz URL Flutter'da ROTA oluyor →
+`/not-found`. Asıl zarar hata ekranı değil: `/not-found` shell'in DIŞINDA, yani
+App Group drain'i hiç çalışmadı — metin kutuda kaldı. Düzeltme üç yerde:
+`SceneDelegate` URL'i `super`'e vermeden düşürüyor (tek taşıyıcı korunuyor),
+router `awIsShareCallback`'i Ana sayfa ile cevaplıyor, `HomeShell` ilk karesinden
+sonra bekleyen yükü süpürüyor (`ref.listen` yalnızca değişimde ateşler). Süitler:
+app **1598** (+8), analyze temiz, format temiz. Negatif kontrol yapıldı: her iki
+yarı ayrı ayrı geri alındığında testler kırmızı. Sürüm etiketi KESİLMEDİ —
+CHANGELOG `[Unreleased]`. Dal: `claude/vel-app-share-error-ax7b1x`.
+Sıradaki iş: PR'ın merge'ü ve cihaz turu — sheet/banner/drain yalnız cihazda
+görülebilir.)
+
+Önceki blok: 2026-09-04 (**Epic 27 — API'NİN BİR ÜRÜN YÜZEYİ OLMASI (istek turu 20).
 OPH-292…297, issue #3.** Rapor üçlü: API erişimi Ayarlar'da yanlış yerde, FAB'ın ikonu yok,
 ve "key oluşturdum, dokümantasyon yok". **Turun cümlesi: özellik v1.7.0'da inmişti — eksik
 olan özellik değil, onu bulunabilir ve kullanılabilir kılan her şeydi.**

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -9388,6 +9388,61 @@ yanlışa dönmüştü._
 _(⏳ Epic 27 kodu tamam; sürüm etiketi bu turda kesilmedi — CHANGELOG `[Unreleased]`
 altında, sekiz yerli sürüm ritüeline girilmedi.)_
 
+## Epic 28 — İstek turu 21: paylaşılan yazı uygulamada bitsin (v1.10.x)
+
+_Sahibin tek raporu, ekran görüntüsüyle: bir yazıyı seçip "Paylaş → AllisWell"
+dedi, uygulama açıldı ve **"Bir şeyler ters gitti — bu bağlantı AllisWell'in bu
+sürümünde bir yere gitmiyor"** dedi; altında `sharemedia-com.alliswell.alliswell:/share`.
+Beklenen: yapay zekânın o yazıyı görev olarak eklemesi._
+
+_**Turun tek cümlesi: paylaşım BAŞARILI olmuştu — hata ekranı, başarılı bir
+paylaşımın uygulamaya "geldim" demek için açtığı URL'i bir ADRES sandığı için
+çıktı.** ADR-0029 o URL'in hiç gelemeyeceğini ölçmüştü (iOS 18); iOS 26'da
+geliyor. Ölçüm eskidi, karar değil._
+
+### OPH-298 — Paylaşım uzantısının geri dönüş URL'i bir adres değil, bir dürtme
+
+- [x] **Kök neden, ekrandaki dizeden okundu (tahmin yok):** `:/share` biçimi
+      go_router'ın `normalizeUri`'sinin `ShareMedia-<bundle id>:share` üzerinde
+      bıraktığı izdir — yani URL `RSIShareViewController.redirectToHostApp()`
+      (`RSIShareViewController.swift:196`) tarafından açılmış ve **uygulamaya
+      ulaşmıştır**. Üç katman üst üste: (1) appex artık ana uygulamayı öne
+      getirebiliyor (iOS 26), (2) `receive_sharing_intent` yalnızca UIScene
+      öncesi `application:openURL:options:` kancalarını kuruyor — bizde
+      `FlutterSceneDelegate` var, yani URL hiçbir plugin'e uğramıyor, (3)
+      sahipsiz URL'i Flutter çerçeveye **rota** olarak veriyor, hiçbir rotaya
+      uymuyor, `onException` `/not-found`'a gönderiyor.
+- [x] **Asıl zarar hata ekranı değildi:** `/not-found` shell'in DIŞINDA, yani
+      `shareBinderProvider` hiç mount olmuyor ve App Group'u boşaltan drain
+      çalışmıyordu. Metin kutuda duruyordu; kullanıcı hem hata görüyor hem
+      görev alamıyordu. Bir geliş, iki çıkmaz sokak.
+- [x] `SceneDelegate` geri dönüş URL'ini `super`'e **vermeden** düşürüyor —
+      böylece rota olmuyor ve plugin de posta kutusunu paralel okuyamıyor
+      (`handleUrl` kutuyu temizlemez; iki okuyucu = bir paylaşım, iki görev).
+      Soğuk yol `connectionOptions` ile geliyor ve orada süzülemez; bu yüzden
+      Dart tarafı da bekçi.
+- [x] `awIsShareCallback` (`core/deep_link.dart`) + router: URL **Ana sayfa**
+      ile cevaplanıyor (hata ekranıyla değil) — ki paylaşımı tüketen shell
+      zaten orada. Oturum kapalıyken "bekleyen derin bağlantı" olarak da
+      hatırlanmıyor: adres olmayan bir şey tekrar oynatılamaz.
+- [x] `HomeShell` ilk karesinden sonra bekleyen paylaşımı **süpürüyor**.
+      `ref.listen` yalnızca DEĞİŞİMDE ateşler ve binder shell'den uzun yaşar:
+      shell ekranda değilken hatırlanan bir yükün tüketicisi yoktu. Raporun
+      "hiçbir şey olmadı" kısmının ikinci yarısı buydu.
+- [x] **ADR-0029 yerinde tadil edildi** ("The premise that expired"): karar
+      duruyor — uzantı hâlâ uygulamayı açmaya çalışmıyor, taşıyıcı hâlâ App
+      Group. Eskiyen yalnızca bir ÖLÇÜM. Kararın ayakta kalma sebebi de kayda
+      geçti: reddedilmeye değil, reddedilme olmadan da çalışmaya kurulmuştu.
+- **Kabul:** üç katman, ADR-0029'un kendi kalıbında — `native_config_test`
+      `super`'e SÜZÜLMÜŞ kümenin verildiğini pinliyor; `deep_link_test`
+      `awIsShareCallback`'i saf olarak; `share_routing_test` üç widget testi:
+      soğuk başlangıç, **sıcak** geri dönüş (düzeltme olmadan `/not-found`'a
+      düşer — raporu birebir üreten test budur) ve shell ekranda değilken gelen
+      yük. Negatif kontrol yapıldı: her iki yarı da ayrı ayrı geri alınıp
+      testlerin kırmızıya döndüğü görüldü.
+- **Doğrulama:** app süiti **1598** (+8), `flutter analyze` temiz,
+      `dart format` değişiklik yok.
+
 ## Backlog / v2 parking lot
 
 - Workspace sharing & roles UI (multi-user workspaces are schema-ready).

--- a/docs/adr/0029-share-extension-notifies-instead-of-redirecting.md
+++ b/docs/adr/0029-share-extension-notifies-instead-of-redirecting.md
@@ -2,7 +2,10 @@
 
 - **Status:** Accepted (2026-08-10, OPH-242) — **amends
   [ADR-0023](0023-stt-and-share-intent-dependencies.md) §3** (the redirect
-  clause only; §1, §2 and the no-network/no-AI guarantee stand)
+  clause only; §1, §2 and the no-network/no-AI guarantee stand).
+  **Amended in place 2026-09-12 (OPH-298): the redirect ARRIVES on iOS 26 —
+  see "The premise that expired" below. The decision stands; one of its
+  measurements does not.**
 - **Context:** feedback round 17 #1 · [AI.md §6](../AI.md) ·
   [TASKS Epic 24](../TASKS.md)
 - **Related:** [ADR-0016](0016-deep-links.md) (URL-scheme handling),
@@ -134,6 +137,57 @@ whole ADR would throw away the sentence this decision leans on.
   showing its dialog, because a dialog can be swallowed and text cannot be
   un-lost.
 
+## The premise that expired (2026-09-12, OPH-298)
+
+Round 21's report, with a screenshot: "Paylaş → AllisWell" showed **"Bir şeyler
+ters gitti — bu bağlantı AllisWell'in bu sürümünde bir yere gitmiyor"**, and
+under it the offending location: `sharemedia-com.alliswell.alliswell:/share`.
+
+That string is the proof, and it says three things at once:
+
+1. **The open arrives.** It is
+   `RSIShareViewController.redirectToHostApp()`'s own URL —
+   `ShareMedia-<bundle id>:share`, `RSIShareViewController.swift:196` — and
+   go_router's `normalizeUri` is what turned `:share` into `:/share`. The L3
+   measurement above was true on iOS 18 and is **false on iOS 26**: the
+   extension can bring the app forward again.
+2. **Nothing native claims it.** `SwiftReceiveSharingIntentPlugin` registers
+   `application:didFinishLaunching:`, `application:openURL:options:` and
+   `application:continue:` — all pre-UIScene. This app runs a
+   `FlutterSceneDelegate` (the plugin's own scene contract starts at 1.9.0,
+   which we do not take), so the URL reaches no plugin.
+3. **Flutter routes what nobody claims.** An unclaimed URL becomes route
+   information, go_router matched none, and `onException` sent it to the
+   `/not-found` screen.
+
+The result was worse than the silence this ADR replaced. The payload **had**
+been saved, the banner **had** been posted, and the user was shown an error for
+a share that succeeded — and because `/not-found` lives OUTSIDE the shell,
+`shareBinderProvider` never mounted, so the drain that would have delivered the
+text never ran. One arrival, two dead ends.
+
+**What changed, and what did not.** The decision is untouched: the extension
+still does not try to open the app, the App Group is still the transport, the
+banner is still a nudge. What changed is that the app now has an answer for the
+callback when it does arrive:
+
+- `SceneDelegate` **drops** it before `super`, so it never becomes route
+  information (and so the plugin can never read the mailbox in parallel with
+  `ShareInboxBridge` — `handleUrl` does not clear it, and two readers is one
+  share becoming two tasks). The COLD path arrives in the scene's connection
+  options, which are read-only, so it cannot be filtered there;
+- `awIsShareCallback` (`core/deep_link.dart`) recognizes the scheme and the
+  router answers it with **Home** instead of the error screen — which is also
+  where the shell that drains the mailbox lives;
+- `HomeShell` sweeps the pending-share holder after its first frame. `ref.listen`
+  fires on CHANGE only, and the binder outlives the shell, so a payload
+  remembered while the shell was off screen had no consumer at all.
+
+**The lesson, recorded because it is the reusable part:** a measurement of what
+the OS refuses is true on the OS version it was taken on. This ADR's decision
+survived precisely because it never depended on the refusal holding — it was
+built to work without the redirect, not to forbid it.
+
 ## Zorlama (how this is enforced)
 
 Three layers, and the first one is only a string guard — say so plainly.
@@ -160,6 +214,14 @@ Three layers, and the first one is only a string guard — say so plainly.
    any other, and a drained payload is **not replayed** across a
    background/foreground cycle. `FakeShareInbox` counts `take()` calls, since
    the failure mode is a count — one share becoming four tasks.
+
+4. **OPH-298's own guards**, in the same three layers: a string guard that
+   `SceneDelegate` hands `super` the FILTERED contexts (`native_config_test`),
+   a pure test of `awIsShareCallback` (`deep_link_test`), and three widget
+   tests in `share_routing_test` — a cold start on the callback URL, a warm one
+   (which lands on `/not-found` without the fix, and is therefore the test that
+   actually reproduces the report), and a payload remembered while the shell is
+   off screen.
 
 **No Dart test can verify the appex's runtime behaviour.** Whether the sheet
 appears, whether the banner lands, and whether a denied user still gets the


### PR DESCRIPTION
## What & why

Task: OPH-298 (Epic 28 — istek turu 21)

**Report (with screenshot):** select a text → "Paylaş → AllisWell" → the app opens on
**"Bir şeyler ters gitti — bu bağlantı AllisWell'in bu sürümünde bir yere gitmiyor"**, with
`sharemedia-com.alliswell.alliswell:/share` underneath. No task was created; the expectation was
that the AI turns the shared text into a task.

**The string on that screen is the diagnosis.** `:/share` is what go_router's `normalizeUri` leaves
on `ShareMedia-<bundle id>:share` — so the URL came from `RSIShareViewController.redirectToHostApp()`
(`RSIShareViewController.swift:196`) and **reached the app**. Three layers:

1. **The open arrives.** ADR-0029 measured it as impossible on iOS 18 (an appex could not foreground
   its host app) and built the App Group drain because of it. On iOS 26 it arrives.
2. **Nothing native claims it.** `receive_sharing_intent` registers only the pre-UIScene
   `application:didFinishLaunching:` / `application:openURL:options:` / `application:continue:` hooks;
   this app runs a `FlutterSceneDelegate` (the plugin's scene contract starts at 1.9.0, which we do
   not take), so the URL reaches no plugin.
3. **Flutter routes what nobody claims.** The unclaimed URL became route information, matched no
   route, and `onException` sent it to `/not-found`.

**The error screen was not the worst of it.** `/not-found` lives *outside* the shell, so
`shareBinderProvider` never mounted and the App Group drain never ran — the shared text sat unread in
the mailbox. One arrival, two dead ends.

### The fix

- **`SceneDelegate` drops the callback before `super`**, so it never becomes route information — and
  the plugin can never read the mailbox alongside `ShareInboxBridge` (`handleUrl` does not clear it;
  two readers is one share becoming two tasks). The cold path arrives in the scene's connection
  options, which are read-only, so Dart guards that end.
- **`awIsShareCallback` + the router answer the URL with Home**, which is also where the shell that
  drains the mailbox lives. It is never remembered as a pending deep link: a non-destination cannot
  be replayed after sign-in.
- **`HomeShell` sweeps the pending-share holder after its first frame.** `ref.listen` fires on CHANGE
  only and the binder outlives the shell, so a payload remembered while the shell was off screen had
  no consumer at all.
- **ADR-0029 amended in place** ("The premise that expired"): the decision stands — the extension
  still does not try to open the app, the App Group is still the transport — only one of its
  measurements expired.

## Checklist (Definition of Done — see AGENTS.md §3)

- [x] JavaScript-only backend policy respected (no `.ts` files) — no backend change
- [x] `npm run lint` + `npm run format:check` pass — `format:check` green; `lint` could not run in
      this container (`@eslint/js` is not installed here), and no JavaScript was touched
- [x] `npm test` passes (+ `npm run test:integration` if infra-affecting) — not affected (app-only change)
- [x] `flutter analyze` + `flutter test` pass (if app changed)
- [x] Tests added/updated
- [x] DB changes are a new knex migration (append-only, with `down`) — none
- [x] Docs updated: `docs/TASKS.md`, `docs/STATE.md`, `CHANGELOG.md` (+ ADR if architectural)
- [x] Conventional commit(s)

## How was this verified?

- `flutter test` — **1598 passed** (+8), `flutter analyze` clean, `dart format --set-exit-if-changed`
  clean, `npm run check:docs` and `npm run check:i18n` green.
- **Negative control, both halves separately:** with the router branch removed, the new warm test
  lands on `/not-found` (the report, reproduced); with the `HomeShell` sweep removed, the off-screen
  payload is never delivered. Restored, both go green.
- Guards, in ADR-0029's own three layers: `native_config_test` pins that `super` receives the
  **filtered** contexts; `deep_link_test` covers `awIsShareCallback` as a pure function;
  `share_routing_test` adds a cold start on the callback URL, a **warm** callback (the test that
  actually reproduces the report — the cold path is also rescued by the auth redirect, so it cannot
  see this alone), and a payload that arrives while the shell is off screen.
- **Device round still owed:** whether the compose sheet, the banner and the drain behave on a real
  iPhone is not something any Dart test can answer (ADR-0029's own note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QPgd2cNvNGwWV4DyoWNA8

---
_Generated by [Claude Code](https://claude.ai/code/session_019QPgd2cNvNGwWV4DyoWNA8)_